### PR TITLE
Add example MemberPage class in lib

### DIFF
--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'scraped'
+
+class MemberPage < Scraped::HTML
+  # field :name do
+  #   noko.css('.name').text.tidy
+  # end
+end

--- a/scraper.rb
+++ b/scraper.rb
@@ -9,7 +9,7 @@ require 'scraperwiki'
 # OpenURI::Cache.cache_path = '.cache'
 require 'scraped_page_archive/open-uri'
 
-# require_rel 'lib'
+require_rel 'lib'
 
 def scrape(h)
   url, klass = h.to_a.first


### PR DESCRIPTION
This shows someone using the boilerplate how to create a Scraped subclass. This also means that we can leave the `require_rel` in so that files dropped in the `lib` directory Just Work.

Fixes #2 